### PR TITLE
Fix Codex app-server null exitCode stream failure

### DIFF
--- a/src/Ai.Tlbx.MidTerm.AgentHost.UnitTests/AppServerControlToolPresentationProjectorTests.cs
+++ b/src/Ai.Tlbx.MidTerm.AgentHost.UnitTests/AppServerControlToolPresentationProjectorTests.cs
@@ -40,6 +40,42 @@ public sealed class AppServerControlToolPresentationProjectorTests
     }
 
     [Fact]
+    public void FromCodex_HandlesNullExitCodeOnStartedCommand()
+    {
+        using var document = JsonDocument.Parse(
+            """
+            {
+              "threadId": "thread-1",
+              "turnId": "turn-1",
+              "startedAt": 1,
+              "item": {
+                "type": "commandExecution",
+                "id": "command-1",
+                "command": "printf hello",
+                "cwd": "/tmp",
+                "processId": null,
+                "source": "agent",
+                "status": "inProgress",
+                "commandActions": [],
+                "aggregatedOutput": null,
+                "exitCode": null,
+                "durationMs": null
+              }
+            }
+            """);
+
+        var presentation = AppServerControlToolPresentationProjector.FromCodex(
+            "command_execution",
+            "in_progress",
+            "Command started",
+            document.RootElement);
+
+        Assert.Equal("command", presentation.Category);
+        Assert.Equal("printf hello", presentation.Subject);
+        Assert.Null(presentation.ExitCode);
+    }
+
+    [Fact]
     public void FromClaude_UsesStructuredToolIdentityAndPath()
     {
         using var document = JsonDocument.Parse("""{"file_path":"Q:\\repos\\tlbx\\README.md"}""");

--- a/src/Ai.Tlbx.MidTerm.AgentHost/Shared/AppServerControlToolPresentationProjector.cs
+++ b/src/Ai.Tlbx.MidTerm.AgentHost/Shared/AppServerControlToolPresentationProjector.cs
@@ -456,6 +456,7 @@ public static class AppServerControlToolPresentationProjector
         {
             if (value.ValueKind == JsonValueKind.Object &&
                 value.TryGetProperty(name, out var property) &&
+                property.ValueKind == JsonValueKind.Number &&
                 property.TryGetInt32(out var result))
             {
                 return result;


### PR DESCRIPTION
## Summary

Fixes a Codex app-server stream failure when a command execution item is reported as started with `exitCode: null`.

Codex uses `null` for the exit code (and duration) while a command is still running. The projector previously called `TryGetInt32` for every present property, which throws `JsonElementHasWrongType` for JSON null and terminates the Codex stream with `Codex App Server Controller stream failed.`.

The parser now only reads integer values from JSON number properties. A regression test covers a realistic `item/started` payload with `exitCode: null` and `durationMs: null`.

## Verification

- `dotnet test src/Ai.Tlbx.MidTerm.AgentHost.UnitTests/Ai.Tlbx.MidTerm.AgentHost.UnitTests.csproj --filter FullyQualifiedName~AppServerControlToolPresentationProjectorTests --nologo` (8 passed)
- Linux Native AOT `mtagenthost` built from this branch and run on the target server with an isolated fake Codex app-server emitting `item/started` with `exitCode: null`; the command item was projected and the turn completed without a stream failure.
- The production `/usr/local/bin/mtagenthost` and service were not replaced or restarted.

The full AgentHost unit-test project currently has unrelated path-resolution failures (`Could not resolve an mtagenthost build output for tests`); 55 tests pass and 27 fail before/independent of this change.