### PR TITLE
Predictable terminal size ownership and responsive input

### DIFF
--- a/src/Ai.Tlbx.MidTerm.UnitTests/BrowserCommandServiceTests.cs
+++ b/src/Ai.Tlbx.MidTerm.UnitTests/BrowserCommandServiceTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace Ai.Tlbx.MidTerm.UnitTests;
 
+[Collection(TimingSensitiveCollection.Name)]
 public class BrowserCommandServiceTests
 {
     [Fact]
@@ -712,16 +713,18 @@ public class BrowserCommandServiceTests
 
         Assert.True(service.TryRegisterClient("c1", "session-a", "default", "preview-a", _ => { }));
         var notBefore = DateTimeOffset.UtcNow.AddMilliseconds(20);
+        // Establish the timestamp boundary before starting the operation's timeout.
+        await Task.Delay(50);
 
         var waitingTask = service.WaitForControllableAsync(
             "https://example.com/",
             sessionId: "session-a",
             previewName: "default",
             requireClientConnectedAfterUtc: notBefore,
-            timeout: TimeSpan.FromSeconds(1),
+            timeout: TimeSpan.FromSeconds(10),
             pollInterval: TimeSpan.FromMilliseconds(10));
 
-        await Task.Delay(50);
+        Assert.False(waitingTask.IsCompleted);
         Assert.True(service.TryRegisterClient("c2", "session-a", "default", "preview-a", _ => { }));
 
         var status = await waitingTask;

--- a/src/Ai.Tlbx.MidTerm.UnitTests/ManagerBarQueueServiceTests.cs
+++ b/src/Ai.Tlbx.MidTerm.UnitTests/ManagerBarQueueServiceTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace Ai.Tlbx.MidTerm.UnitTests;
 
+[Collection(TimingSensitiveCollection.Name)]
 public sealed class ManagerBarQueueServiceTests : IAsyncDisposable
 {
     private readonly string _stateDir;
@@ -527,7 +528,8 @@ public sealed class ManagerBarQueueServiceTests : IAsyncDisposable
             repeatCount: 2);
 
         _timeProvider.Advance(TimeSpan.FromSeconds(2));
-        await Task.Delay(700);
+        await WaitForQueueStateAsync(() =>
+            service.GetSnapshot(["session-1"]).SingleOrDefault()?.CompletedCycles == 1);
 
         Assert.Equal(["recurring status"], runtime.SentPrompts);
         var rearmed = Assert.Single(service.GetSnapshot(["session-1"]));
@@ -535,7 +537,7 @@ public sealed class ManagerBarQueueServiceTests : IAsyncDisposable
         Assert.NotNull(rearmed.NextRunAt);
 
         _timeProvider.Advance(TimeSpan.FromSeconds(3));
-        await Task.Delay(700);
+        await WaitForQueueStateAsync(() => service.GetSnapshot(["session-1"]).Count == 0);
 
         Assert.Equal(["recurring status", "recurring status"], runtime.SentPrompts);
         Assert.Empty(service.GetSnapshot(["session-1"]));
@@ -628,6 +630,15 @@ public sealed class ManagerBarQueueServiceTests : IAsyncDisposable
 
         Assert.Single(runtime.SentTurns);
         Assert.Equal("queued turn", runtime.SentTurns[0].Text);
+    }
+
+    private static async Task WaitForQueueStateAsync(Func<bool> condition)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        while (!condition())
+        {
+            await Task.Delay(10, timeout.Token);
+        }
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Ai.Tlbx.MidTerm.UnitTests/MuxClientTests.cs
+++ b/src/Ai.Tlbx.MidTerm.UnitTests/MuxClientTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace Ai.Tlbx.MidTerm.UnitTests;
 
+[Collection(TimingSensitiveCollection.Name)]
 public sealed class MuxClientTests
 {
     [Fact]

--- a/src/Ai.Tlbx.MidTerm.UnitTests/TimingSensitiveCollection.cs
+++ b/src/Ai.Tlbx.MidTerm.UnitTests/TimingSensitiveCollection.cs
@@ -1,0 +1,11 @@
+using Xunit;
+
+namespace Ai.Tlbx.MidTerm.UnitTests;
+
+// These tests exercise real timers and bounded flush latency. Keep unrelated
+// parallel test work from consuming their scheduling budget on CI runners.
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class TimingSensitiveCollection
+{
+    public const string Name = "Timing-sensitive services";
+}

--- a/src/npx-launcher/package.json
+++ b/src/npx-launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tlbx-ai/midterm",
-  "version": "10.16.0",
+  "version": "10.16.1-dev",
   "description": "Quick-trial launcher for tlbx, the self-hosted browser control station for remote AI coding agents",
   "license": "AGPL-3.0-only",
   "repository": {

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
-  "web": "10.16.0",
-  "pty": "10.16.0",
+  "web": "10.16.1-dev",
+  "pty": "10.16.1-dev",
   "protocol": 1,
-  "minCompatiblePty": "10.16.0-dev"
+  "minCompatiblePty": "10.16.1-dev"
 }


### PR DESCRIPTION
## Summary
Promoting `10.16.1-dev` to stable `10.16.1` - includes 1 dev releases since v10.16.0.

## Changelog

### v10.16.1-dev - Predictable terminal size ownership and responsive input
- Passive monitoring devices preserve the desktop terminal size owner across inactivity, reloads and browser returns. Ownership moves on eligible user input or explicit takeover.
- Keep desktop terminal text at its natural size when the viewport height changes while reading scrollback.
- Enforce browser ownership and epochs for terminal resizing; headless REST and tmux cannot overwrite browser-owned dimensions.
- Track real browser input on the server, exclude terminal-generated replies, preserve Hub browser identity, and keep input independent of ownership file writes and pending resize acknowledgements.

