### PR TITLE
Predictable terminal size ownership and responsive input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -726,14 +726,21 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Verify local .NET SDK on self-hosted Windows runner
+      - name: Set up pinned .NET SDK on self-hosted Windows runner
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        env:
+          DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet-sdk
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Verify selected .NET SDK
         shell: pwsh
         run: |
-          $sdks = dotnet --list-sdks
-          if (-not ($sdks | Select-String '^10\.0\.')) {
-            throw "Required .NET 10 SDK not found on self-hosted runner."
+          $selectedSdk = dotnet --version
+          if ($LASTEXITCODE -ne 0 -or $selectedSdk -ne $env:DOTNET_VERSION) {
+            throw "Required .NET SDK $env:DOTNET_VERSION was not selected (actual: $selectedSdk)."
           }
-          dotnet --version
+          Write-Host "Using .NET SDK $selectedSdk"
 
       - name: Download frontend
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/src/npx-launcher/package.json
+++ b/src/npx-launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tlbx-ai/midterm",
-  "version": "10.16.1",
+  "version": "10.16.2-dev",
   "description": "Quick-trial launcher for tlbx, the self-hosted browser control station for remote AI coding agents",
   "license": "AGPL-3.0-only",
   "repository": {

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
-  "web": "10.16.1",
-  "pty": "10.16.1",
+  "web": "10.16.2-dev",
+  "pty": "10.16.2-dev",
   "protocol": 1,
-  "minCompatiblePty": "10.16.1-dev"
+  "minCompatiblePty": "10.16.2-dev"
 }


### PR DESCRIPTION
## Summary
Promoting `10.16.2-dev` to stable `10.16.2` - includes 1 dev releases since v10.16.1.

## Changelog

### v10.16.2-dev - Predictable terminal size ownership and responsive input
- Passive monitoring devices preserve the desktop terminal size owner across inactivity, reloads and browser returns. Ownership moves on eligible user input or explicit takeover.
- Keep desktop terminal text at its natural size when the viewport height changes while reading scrollback.
- Enforce browser ownership and epochs for terminal resizing; headless REST and tmux cannot overwrite browser-owned dimensions.
- Track real browser input on the server, exclude terminal-generated replies, preserve Hub browser identity, and keep input independent of ownership file writes and pending resize acknowledgements.

